### PR TITLE
CI: Configure Workflows for Trusted Publishing

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -24,3 +24,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
+
+    - name: Build
+      shell: bash
+      run: pnpm build

--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -9,9 +9,9 @@ runs:
         version: 10
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 22.x
+        node-version: 24 # Node 24 uses npm 11.6.2; need a minimum NPM version of 11.5.2 for provenance
         registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
 
@@ -24,7 +24,3 @@ runs:
     - name: Install dependencies
       shell: bash
       run: pnpm install
-
-    - name: Build
-      shell: bash
-      run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,11 @@ on:
       - 'packages/**'
       - '.npmrc'
       - 'biome.json'
-      - 'bunfig.toml'
       - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
       - 'tsconfig.build.json'
       - 'tsconfig.json'
-      - 'tsup.config.ts'
     branches:
       - main
 
@@ -19,12 +19,18 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
+    if: github.repository == 'amandaguthrie/panda-css-presets'
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to create release (changesets/action)
+      id-token: write # OpenID Connect token needed for provenance
+      pull-requests: write # to create pull request (changesets/action)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # This makes actions fetch all git history so changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Install
@@ -39,7 +45,8 @@ jobs:
         with:
           publish: pnpm release
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          # Use OIDC for npm authentication instead of NPM_TOKEN
+          NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           GITHUB_TOKEN: ${{secrets.GH_PAT}}
 
       - name: Release to dev tag
@@ -49,5 +56,6 @@ jobs:
           pnpm release:dev:version
           pnpm release:dev:publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          # Use OIDC for npm authentication instead of NPM_TOKEN
+          NPM_TOKEN: '' # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           GITHUB_TOKEN: ${{secrets.GH_PAT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,8 @@ jobs:
           # This makes actions fetch all git history so changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Install
+      - name: Install & Build
         uses: ./.github/composite-actions/install
-
-      - name: Build packages
-        run: pnpm build
 
       - name: Publish packages
         id: changesets


### PR DESCRIPTION
Switch from NPM Tokens to OIDC Trusted Publishing